### PR TITLE
Remove unused fields in control

### DIFF
--- a/PonyDebuggerInjected/Package/DEBIAN/control
+++ b/PonyDebuggerInjected/Package/DEBIAN/control
@@ -4,10 +4,7 @@ Version: 1.0-1
 Description: 
 Section: Tweaks
 Depends: firmware (>= 5.0), mobilesubstrate, preferenceloader
-Conflicts: 
-Replaces: 
 Priority: optional
 Architecture: iphoneos-arm
 Author: Den
-dev: 
 Homepage: https://github.com/dtrukr/PonyDebuggerInjected

--- a/PonyDebuggerInjected/PonyDebuggerInjected.mm
+++ b/PonyDebuggerInjected/PonyDebuggerInjected.mm
@@ -19,6 +19,11 @@ static void PreferenceChangedPostedNotification(CFNotificationCenterRef center, 
 
 CHConstructor // code block that runs immediately upon load
 {
+	// Don't load in SpringBoard to avoid crash
+	if([[[NSBundle mainBundle] bundleIdentifier] isEqualToString:@"com.apple.springboard"]) {
+		return;
+	}
+	
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     
 	[PonyDebuggerInjectedController sharedInstance];


### PR DESCRIPTION
This prevents errors in Cydia, which fails to load the package.
Also increased version.
